### PR TITLE
Return bans based on IP and PID

### DIFF
--- a/database/login.go
+++ b/database/login.go
@@ -114,6 +114,17 @@ func LoginUserToGPCM(pool *pgxpool.Pool, ctx context.Context, userId uint64, gsb
 		banExists = false
 	}
 
+	if banExists {
+		if banTOS {
+			logging.Warn("DATABASE", "Profile", aurora.Cyan(user.ProfileId), "is banned")
+			return User{RestrictedDeviceId: bannedDeviceId}, ErrProfileBannedTOS
+		}
+
+		logging.Warn("DATABASE", "Profile", aurora.Cyan(user.ProfileId), "is restricted")
+		user.Restricted = true
+		user.RestrictedDeviceId = bannedDeviceId
+	}
+
 	return user, nil
 }
 

--- a/database/login.go
+++ b/database/login.go
@@ -105,7 +105,7 @@ func LoginUserToGPCM(pool *pgxpool.Pool, ctx context.Context, userId uint64, gsb
 	var banTOS bool
 	var bannedDeviceId uint32
 	timeNow := time.Now()
-	err = pool.QueryRow(ctx, SearchUserBan, user.ProfileId, user.NgDeviceId, ipAddress, timeNow).Scan(&banExists, &banTOS, &bannedDeviceId)
+	err = pool.QueryRow(ctx, SearchUserBan, user.ProfileId, ipAddress, timeNow).Scan(&banExists, &banTOS, &bannedDeviceId)
 	if err != nil {
 		if err != pgx.ErrNoRows {
 			return User{}, err

--- a/database/user.go
+++ b/database/user.go
@@ -10,6 +10,7 @@ import (
 )
 
 const (
+	// NOTE: SearchUserBan is only used in one place, so we can change it for Retro Rewind with no issues
 	InsertUser              = `INSERT INTO users (user_id, gsbrcd, password, ng_device_id, email, unique_nick) VALUES ($1, $2, $3, $4, $5, $6) RETURNING profile_id`
 	InsertUserWithProfileID = `INSERT INTO users (profile_id, user_id, gsbrcd, password, ng_device_id, email, unique_nick) VALUES ($1, $2, $3, $4, $5, $6, $7)`
 	UpdateUserTable         = `UPDATE users SET firstname = CASE WHEN $3 THEN $2 ELSE firstname END, lastname = CASE WHEN $5 THEN $4 ELSE lastname END, open_host = CASE WHEN $7 THEN $6 ELSE open_host END WHERE profile_id = $1`
@@ -22,7 +23,7 @@ const (
 	GetUserProfileID        = `SELECT profile_id, ng_device_id, email, unique_nick, firstname, lastname, open_host FROM users WHERE user_id = $1 AND gsbrcd = $2`
 	UpdateUserLastIPAddress = `UPDATE users SET last_ip_address = $2, last_ingamesn = $3 WHERE profile_id = $1`
 	UpdateUserBan           = `UPDATE users SET has_ban = true, ban_issued = $2, ban_expires = $3, ban_reason = $4, ban_reason_hidden = $5, ban_moderator = $6, ban_tos = $7 WHERE profile_id = $1`
-	SearchUserBan           = `SELECT has_ban, ban_tos, ng_device_id FROM users WHERE has_ban = true AND (profile_id = $1 OR ng_device_id = $2 OR last_ip_address = $3) AND (ban_expires IS NULL OR ban_expires > $4) ORDER BY ban_tos DESC LIMIT 1`
+	SearchUserBan           = `SELECT has_ban, ban_tos, ng_device_id FROM users WHERE has_ban = true AND (profile_id = $1 OR last_ip_address = $3) AND (ban_expires IS NULL OR ban_expires > $4) ORDER BY ban_tos DESC LIMIT 1`
 	DisableUserBan          = `UPDATE users SET has_ban = false WHERE profile_id = $1`
 
 	GetMKWFriendInfoQuery    = `SELECT mariokartwii_friend_info FROM users WHERE profile_id = $1`

--- a/database/user.go
+++ b/database/user.go
@@ -23,7 +23,7 @@ const (
 	GetUserProfileID        = `SELECT profile_id, ng_device_id, email, unique_nick, firstname, lastname, open_host FROM users WHERE user_id = $1 AND gsbrcd = $2`
 	UpdateUserLastIPAddress = `UPDATE users SET last_ip_address = $2, last_ingamesn = $3 WHERE profile_id = $1`
 	UpdateUserBan           = `UPDATE users SET has_ban = true, ban_issued = $2, ban_expires = $3, ban_reason = $4, ban_reason_hidden = $5, ban_moderator = $6, ban_tos = $7 WHERE profile_id = $1`
-	SearchUserBan           = `SELECT has_ban, ban_tos, ng_device_id FROM users WHERE has_ban = true AND (profile_id = $1 OR last_ip_address = $3) AND (ban_expires IS NULL OR ban_expires > $4) ORDER BY ban_tos DESC LIMIT 1`
+	SearchUserBan           = `SELECT has_ban, ban_tos, ng_device_id FROM users WHERE has_ban = true AND (profile_id = $1 OR last_ip_address = $2) AND (ban_expires IS NULL OR ban_expires > $3) ORDER BY ban_tos DESC LIMIT 1`
 	DisableUserBan          = `UPDATE users SET has_ban = false WHERE profile_id = $1`
 
 	GetMKWFriendInfoQuery    = `SELECT mariokartwii_friend_info FROM users WHERE profile_id = $1`


### PR DESCRIPTION
Returns the normal wfc ban checks, but removes checking for ng_device_id to avoid banning all dolphin users.